### PR TITLE
Adjust .gitmodules for extensions/{site,ipc,feeds}

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,10 @@
 	url = git://github.com/AKSW/Erfurt.git
 [submodule "extensions/site"]
 	path = extensions/site
-	url = git@github.com:AKSW/site.ontowiki.git
+	url = git://github.com/AKSW/site.ontowiki.git
 [submodule "extensions/ipc"]
 	path = extensions/ipc
-	url = git@github.com:AKSW/ipc.ontowiki.git
+	url = git://github.com/AKSW/ipc.ontowiki.git
 [submodule "extensions/feeds"]
 	path = extensions/feeds
-	url = git@github.com:AKSW/feeds.ontowiki.git
+	url = git://github.com/AKSW/feeds.ontowiki.git


### PR DESCRIPTION
The submodules extensions/{site,ipc,feeds} failed checking out with both of these commands:
```
$ git clone https://github.com/AKSW/aksw.org --recursive
$ git clone https://github.com/AKSW/aksw.org \
  && cd aksw.org \
  && git submodule --init --recursive
```
I've tested this on both my local setup and inside a docker container
so that I can be certain that checkout of submodules didn't work before
but works now.